### PR TITLE
Set binaries and SHA hashes for multiple platforms

### DIFF
--- a/Formula/easy-subnet.rb
+++ b/Formula/easy-subnet.rb
@@ -1,12 +1,17 @@
 ##
 ## taken from https://github.com/sathyavijayan/homebrew-kapi/blob/master/Formula/easy-subnet.rb
 ##
+require __dir__ + '/../helpers/platform_helper'
+
 class EasySubnet < Formula
+  include PlatformHelper
+
   desc     "A command-line tool for easy split subnets into equally sized networks"
   homepage "https://github.com/BrunoBonacci/easy-subnet.git"
-  url      "https://github.com/BrunoBonacci/easy-subnet/releases/download/0.4.1/easy-subnet-homebrew-Darwin-x86_64.tar.gz"
-  sha256   "68b84372be7e14663609e7794d9bb7a763dbe310404cea5b06e4211b0c502a81"
+  url      "https://github.com/BrunoBonacci/easy-subnet/releases/download/0.4.1/easy-subnet-homebrew-#{OS}-x86_64.tar.gz"
   version  "0.4.1"
+  sha256_Darwin "68b84372be7e14663609e7794d9bb7a763dbe310404cea5b06e4211b0c502a81"
+  sha256_Linux "fa34948eb5194bc70c5aa7456c74a732eca4c40ab8d6de49c88b0303a8c5f4d3"
 
   depends_on "curl"
 

--- a/helpers/platform_helper.rb
+++ b/helpers/platform_helper.rb
@@ -1,0 +1,43 @@
+# Adds the following helpers:
+
+# `OS` - Variable that contains the friendly name of the host
+# operating system (eg. Linux, Darwin etc.,)
+# `sha256_[OS]` - dynamic functions that support setting SHA hashes
+# for each operating system. (eg. sha256_Linux, sha256_Darwin etc)
+module PlatformHelper
+  OS = case RbConfig::CONFIG['host_os'].downcase
+       when /linux/
+         "Linux"
+       when /darwin/
+         "Darwin"
+       when /freebsd/
+         "Freebsd"
+       when /netbsd/
+         "Netbsd"
+       when /openbsd/
+         "Openbsd"
+       when /sunos|solaris/
+         "Solaris"
+       when /mingw|mswin/
+         "Windows"
+       else
+         RbConfig::CONFIG['host_os'].downcase
+       end
+
+  def self.included(host_class)
+    host_class.extend ShaHelper
+  end
+
+  module ShaHelper
+
+    def method_missing(method_name, *args, &block)
+      p = method_name.to_s.match(/sha256_(.*)/)
+      sha256(args[0]) if p != nil && p[1] == OS
+    end
+
+    def respond_to?(method_name, include_private = false)
+      method_name.to_s.start_with?('sha256_') || super
+    end
+  end
+
+end


### PR DESCRIPTION
I added a new helper to expose the `OS` name and also the ability to set hashes for multiple platforms.