### PR TITLE
Fix "bottle :unneeded" deprecation warning

### DIFF
--- a/Formula/easy-subnet.rb
+++ b/Formula/easy-subnet.rb
@@ -15,8 +15,6 @@ class EasySubnet < Formula
 
   depends_on "curl"
 
-  bottle :unneeded
-
   def install
     bin.install "easy-subnet"
   end

--- a/Formula/jqx.rb
+++ b/Formula/jqx.rb
@@ -7,8 +7,6 @@ class Jqx < Formula
 
   depends_on "planck"
 
-  bottle :unneeded
-
   def install
     bin.install "jqx"
     bin.install "plkx"

--- a/Formula/one-config.rb
+++ b/Formula/one-config.rb
@@ -8,8 +8,6 @@ class OneConfig < Formula
   sha256   "9915258f941a4b15472fe139762a0cd38b8e71dbd674596ac61729a68ca2127d"
   version  "0.16.4"
 
-  bottle :unneeded
-
   def install
     bin.install "1cfg"
     bin.install "1cfg.jar"

--- a/Formula/rolling-update.rb
+++ b/Formula/rolling-update.rb
@@ -8,8 +8,6 @@ class RollingUpdate < Formula
   sha256   "eead922f500af9ea88b040a7b2d8c5ff196342f9389b0779aeb927fa498c7951"
   version  "0.3.1"
 
-  bottle :unneeded
-
   def install
     bin.install "rolling-update"
     bin.install "rolling-update.jar"

--- a/Formula/synapse.rb
+++ b/Formula/synapse.rb
@@ -10,8 +10,6 @@ class Synapse < Formula
   sha256_Darwin "c436ec4f561313bb78ee68e302f3ca91920f3becf135ea6964335bef15b8f921"
   sha256_Linux  "be680cd3f0b194c858b045987c8fda2e87f38d30e5d1de486703c11d9e11f744"
 
-  bottle :unneeded
-
   def install
     bin.install "synapse"
   end


### PR DESCRIPTION
Hey, thanks very much for these tools, and sorry for the bad trolling PR title. After updating my local packages with:

``` zsh
$ brew update
  brew upgrade
  brew cleanup -s
```

I stumbled upon this wall of warnings:

``` log
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/rolling-update.rb:11

Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/one-config.rb:11

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/rolling-update.rb:11

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/one-config.rb:11

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/rolling-update.rb:11

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the brunobonacci/lazy-tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/brunobonacci/homebrew-lazy-tools/Formula/one-config.rb:11
```

And so I reported this issue to the maintainer.